### PR TITLE
[#XXX] Failed to parse config.json, error= {} while creating Orchetrator

### DIFF
--- a/packages/orchestratorlib/src/orchestratorhelper.ts
+++ b/packages/orchestratorlib/src/orchestratorhelper.ts
@@ -12,7 +12,7 @@ import {ITextUtteranceLabelMapDataStructure, Label, LabelStructureUtility, Label
 import {LabelResolver} from './labelresolver';
 import {UtilityLabelResolver} from './utilitylabelresolver';
 import {PrebuiltToRecognizerMap} from './resources/recognizer-map';
-import {OrchestratorBuild, OrchestratorSettings} from '.';
+import {OrchestratorBuild} from '.';
 import {Utility} from './utility';
 import {Utility as UtilityDispatcher} from '@microsoft/bf-dispatcher';
 
@@ -291,6 +291,7 @@ export class OrchestratorHelper {
     }
 
     Utility.writeStringLineToConsoleStdout(`Processing ${filePath}...`);
+    const filename: string = path.basename(filePath);
     try {
       switch (ext) {
         case '.lu':
@@ -312,9 +313,6 @@ export class OrchestratorHelper {
           break;
 
         case '.json':
-          if (filePath.endsWith(OrchestratorSettings.OrchestratorSettingsFileName)) {
-            return;
-          }
           if (OrchestratorHelper.getIntentsEntitiesUtterances(
             fs.readJsonSync(filePath),
             routingName,
@@ -324,15 +322,16 @@ export class OrchestratorHelper {
             utteranceEntityLabelDuplicateMap)) {
             return;
           }
-          if (!OrchestratorHelper.getJsonIntentsEntitiesUtterances(
+          if (OrchestratorHelper.getJsonIntentsEntitiesUtterances(
             fs.readJsonSync(filePath),
             routingName,
             utteranceLabelsMap,
             utteranceLabelDuplicateMap,
             utteranceEntityLabelsMap,
             utteranceEntityLabelDuplicateMap)) {
-            throw new Error('Failed to parse LUIS or JSON file on intent/entity labels');
+            return;
           }
+          Utility.writeStringLineToConsoleStdout(`  - Failed to parse file '${filename}'. This file will be ignored.`);
           break;
 
         case '.tsv':


### PR DESCRIPTION
Fixes # 6531 (create issue first)

## Description
This PR updates how the Orchestrator processing file functionality behaves when a custom path in the `--in` argument is provided, that could have multiple JSON files that aren't supported by the Orchestrator process. By just logging out to the console if a JSON file isn't supported, instead of failing.

## Specific Changes
- Removes throw Error.
- Adds failed to parse JSON file log.
- Updates conditions around JSON files for consistency.

## Testing
The following image shows the before and after the changes.
![image](https://user-images.githubusercontent.com/62260472/190418606-1fc2cec4-dab6-4244-91a2-5a3c811e44bb.png)