### PR TITLE
Fix SM02383 and SM04514 CodeQL issues

### DIFF
--- a/packages/chatdown/utils/index.js
+++ b/packages/chatdown/utils/index.js
@@ -565,5 +565,5 @@ function* fileLineIterator(fileContents) {
 }
 
 function getHashCode(contents) {
-    return crypto.createHash('sha1').update(contents).digest('base64')
+    return crypto.createHash('sha256').update(contents).digest('base64')
 }

--- a/packages/dialog/src/library/hash.ts
+++ b/packages/dialog/src/library/hash.ts
@@ -10,7 +10,7 @@ import * as ppath from 'path'
 
 export function computeHash(val: string): string {
     // We write out OS.EOL, but want hash independent of endings
-    return crypto.createHash('md5').update(val.replace(/\r/g, '')).digest('hex')
+    return crypto.createHash('sha256').update(val.replace(/\r/g, '')).digest('hex')
 }
 
 // Normalize to OS line endings

--- a/packages/dialog/src/library/hash.ts
+++ b/packages/dialog/src/library/hash.ts
@@ -10,7 +10,7 @@ import * as ppath from 'path'
 
 export function computeHash(val: string): string {
     // We write out OS.EOL, but want hash independent of endings
-    return crypto.createHash('md5').update(val.replace(/\r/, '')).digest('hex')
+    return crypto.createHash('md5').update(val.replace(/\r/g, '')).digest('hex')
 }
 
 // Normalize to OS line endings

--- a/packages/dispatcher/src/utility/CryptoUtility.ts
+++ b/packages/dispatcher/src/utility/CryptoUtility.ts
@@ -62,15 +62,27 @@ export class CryptoUtility {
         return hash.update(input).digest("hex");
     }
 
+    /**
+     * @deprecated Use `CryptoUtility.getObjectSha256Hash` instead.
+     *
+     * Products must use the SHA-2 family of hash algorithms.
+     * Other algorithms are susceptible to hash collisions, which effectively *break* them.
+     *
+     * Recommendation: SHA256, SHA384, SHA512.
+     */
     public static getObjectSha1Hash(objectValue: object): string|Int32Array {
-        const hash = crypto.createHash("sha1");
-        hash.update(CryptoUtility.salt);
-        return hash.update(Utility.jsonStringify(objectValue)).digest("hex");
+        return CryptoUtility.getObjectSha256Hash(objectValue);
     }
+    /**
+     * @deprecated Use `CryptoUtility.getStringSha256Hash` instead.
+     *
+     * Products must use the SHA-2 family of hash algorithms.
+     * Other algorithms are susceptible to hash collisions, which effectively *break* them.
+     *
+     * Recommendation: SHA256, SHA384, SHA512.
+     */
     public static getStringSha1Hash(input: string): string|Int32Array {
-        const hash = crypto.createHash("sha1");
-        hash.update(CryptoUtility.salt);
-        return hash.update(input).digest("hex");
+        return CryptoUtility.getStringSha256Hash(input);
     }
 
     public static getCryptoHashes(): string[] {

--- a/packages/lg/test/commands/lg/verify.test.ts
+++ b/packages/lg/test/commands/lg/verify.test.ts
@@ -34,7 +34,7 @@ describe('lg:verify lg file', async () => {
     '-r',
     '-f'])
   .it('', async () => {
-    const result =  await fs.pathExists(path.join(generatedFolderPath, '1.diagnostic.txt'))
+    const result =  await fs.pathExists(path.join(__dirname, generatedFolderPath, '1.diagnostic.txt'))
     expect(result).to.deep.equal(false)
   })
 
@@ -48,20 +48,21 @@ describe('lg:verify lg file', async () => {
     '-r',
     '-f'])
   .it('', async () => {
-    const result =  await fs.pathExists(path.join(generatedFolderPath, '2.diagnostic.txt'))
+    const result =  await fs.pathExists(path.join(__dirname, generatedFolderPath, '2.diagnostic.txt'))
     expect(result).to.deep.equal(false)
   })
 
   // error lg file
-  const errorFileName = '3.lg'
-
   test
   .command(['lg:verify',
     '--in',
-    path.join(__dirname, testcaseFolderPath, errorFileName),
+    path.join(__dirname, testcaseFolderPath, '3.lg'),
+    '--out',
+    generatedFolder,
     '-r',
     '-f'])
   .it('', async () => {
-    // show diagnostics in terminal
+    const result =  await fs.pathExists(path.join(__dirname, generatedFolderPath, '3.diagnostic.txt'))
+    expect(result).to.deep.equal(true)
   })
 })

--- a/packages/lu/src/parser/luis/luConverter.js
+++ b/packages/lu/src/parser/luis/luConverter.js
@@ -529,7 +529,7 @@ const addUtteranceToCollection = function (attribute, srcItem, matchInTarget) {
     if(attribute === 'text') {
         matchInTarget.utterances.push(srcItem); 
     } else {
-        let utteranceFromPattern = new helperClasses.utterances(srcItem.pattern.replace('{', '{@'),srcItem.intent,[]);
+        let utteranceFromPattern = new helperClasses.utterances(srcItem.pattern.replace(/{/g, '{@'),srcItem.intent,[]);
         utteranceFromPattern.isPattern = true;
         matchInTarget.utterances.push(utteranceFromPattern);
     }

--- a/packages/lu/test/fixtures/verified/Child_Entity_With_Spaces.lu
+++ b/packages/lu/test/fixtures/verified/Child_Entity_With_Spaces.lu
@@ -161,7 +161,7 @@
 - please order {@Order={@FullPizzaWithModifiers={@Quantity=two} {@Crust=pan crust} {@Size=small} {@PizzaType=pepperoni pizza} {@ToppingModifiers={@Modifier=with} {@Topping=beef}}} and {@FullPizzaWithModifiers={@Quantity=three} {@Size=medium} {@PizzaType=cheese pizza} {@ToppingModifiers=with italian sausage}}}
 - request {@Order={@FullPizzaWithModifiers={@Quantity=seven} {@Size=large} {@PizzaType=honolulu hawaiian pizza} {@ToppingModifiers={@Modifier=with} {@Topping=bacon} and {@Topping=salami}}} and {@SideOrder={@SideProduct=add chicken wings}}}
 - three pizzas large chicken barbeque for tomorrow evening
-- {@number} pizzas {SizeList} {ToppingList} {ToppingList} for {datetimeV2}
+- {@number} pizzas {@SizeList} {@ToppingList} {@ToppingList} for {@datetimeV2}
 
 
 @ intent ModifyOrder usesFeatures ToppingDescriptor,SizeDescriptor,QuantityDescriptor,ModifierDescriptor,ScopeDescriptor,CrustDescriptor,GreetingDescriptor

--- a/packages/lu/test/fixtures/verified/LUISAppWithPAInherits.lu
+++ b/packages/lu/test/fixtures/verified/LUISAppWithPAInherits.lu
@@ -186,7 +186,7 @@
 - would you add {@ToDo.TaskContent=heavy cream} to the todos list
 - would you please add todo item of {@ToDo.TaskContent=all hands meeting next monday}
 - ^(add|create|append) an item [(called|about|of)] "{@ToDo.TaskContent.Any}" [as (next|first|last) task][(in|on|to) my (to do|to-do|todos) list]
-- ^[(can you|could you|would you)] [please] (put|add|append) {@ToDo.TaskContent} [and] [{ToDo.TaskContent}] (on|to)[my][(to do|todos|todo)]list
+- ^[(can you|could you|would you)] [please] (put|add|append) {@ToDo.TaskContent} [and] [{@ToDo.TaskContent}] (on|to)[my][(to do|todos|todo)]list
 
 
 > # Entity definitions

--- a/packages/luis/test/fixtures/verified/LUISAppWithPAInherits.lu
+++ b/packages/luis/test/fixtures/verified/LUISAppWithPAInherits.lu
@@ -186,7 +186,7 @@
 - would you add {@ToDo.TaskContent=heavy cream} to the todos list
 - would you please add todo item of {@ToDo.TaskContent=all hands meeting next monday}
 - ^(add|create|append) an item [(called|about|of)] "{@ToDo.TaskContent.Any}" [as (next|first|last) task][(in|on|to) my (to do|to-do|todos) list]
-- ^[(can you|could you|would you)] [please] (put|add|append) {@ToDo.TaskContent} [and] [{ToDo.TaskContent}] (on|to)[my][(to do|todos|todo)]list
+- ^[(can you|could you|would you)] [please] (put|add|append) {@ToDo.TaskContent} [and] [{@ToDo.TaskContent}] (on|to)[my][(to do|todos|todo)]list
 
 
 > # Entity definitions

--- a/packages/luis/test/fixtures/verified/luis_sorted_missing_member.lu
+++ b/packages/luis/test/fixtures/verified/luis_sorted_missing_member.lu
@@ -17,8 +17,8 @@
 @ intent AskForUserName usesFeatures Want,question,abc
 
 # BookFlight
-- book flight from {@city:fromCity} to {city:toCity}
-- [can you] get me a flight from {@city:fromCity} to {city:toCity}
+- book flight from {@city:fromCity} to {@city:toCity}
+- [can you] get me a flight from {@city:fromCity} to {@city:toCity}
 - get me a flight to {@city:toCity}
 - I need to fly from {@city:fromCity}
 

--- a/packages/qnamaker/test/fixtures/verified/LUISAppWithPAInherits.lu
+++ b/packages/qnamaker/test/fixtures/verified/LUISAppWithPAInherits.lu
@@ -186,7 +186,7 @@
 - would you add {@ToDo.TaskContent=heavy cream} to the todos list
 - would you please add todo item of {@ToDo.TaskContent=all hands meeting next monday}
 - ^(add|create|append) an item [(called|about|of)] "{@ToDo.TaskContent.Any}" [as (next|first|last) task][(in|on|to) my (to do|to-do|todos) list]
-- ^[(can you|could you|would you)] [please] (put|add|append) {@ToDo.TaskContent} [and] [{ToDo.TaskContent}] (on|to)[my][(to do|todos|todo)]list
+- ^[(can you|could you|would you)] [please] (put|add|append) {@ToDo.TaskContent} [and] [{@ToDo.TaskContent}] (on|to)[my][(to do|todos|todo)]list
 
 
 > # Entity definitions


### PR DESCRIPTION
#minor

> [!NOTE]
> Both [getObjectSha1Hash and getStringSha1Hash](https://github.com/microsoft/botframework-cli/blob/main/packages/dispatcher/src/utility/CryptoUtility.ts#L65-L74) methods are using `SHA1` algorithm.
> Since there is no ID/reference publicly available for the CodeQL SM04514 issue to skip it, we decided to deprecate these methods, recomending to use `SHA-2` family of hash algorithms instead, as it suggets the `Weak Hashes` alert.
> While underneath these functions, it will no longer execute `SHA1` code, and instead they will redirect to `SHA256` methods.

## Description
This PR fixes the [SM02383](https://codeql.github.com/codeql-query-help/javascript/js-incomplete-sanitization) and SM04514 CodeQL issues, updates a few tests due to the changes, and refactored an existing failing test.

## Specific changes
- SM02383
  - Added the `g` flag for RegExp cases in the `replace` method, located in the `hash.ts` and `luConverted.js` files. To replace all references found across a string value.
  - Updated tests to support the mentioned changes. Now it should replace `{` with `{@` in all references found, instead of just the first one.
    - > **Note:** parsing LU Content to LU JSON it was already detecting `{@` references globally within a string, so this likely could have been a bug.
- SM04514 
  - Updated all `sha1` and `md5` references to `sha256`.
  - Updated the `CryptoUtility.ts` file to deprecate the `sha1` methods to use the `sha256` instead.
- Fixed an existing test that was failing on purpose, but logging the output to the terminal, causing the CI pipeline to fail. Now it validates with a .txt file, like the other tests do.

## Testing
The following images show how the LU parser from JSON to Content replaces all `{` (bracket) references, and the CI pipeline working.
![image](https://github.com/southworks/botframework-cli/assets/62260472/061c91af-b0c7-4a57-aa0f-3e699cc33bff)
![image](https://github.com/southworks/botframework-cli/assets/62260472/b519c42c-66ac-4ca5-ad6e-2eed73a7a656)
