### PR TITLE
fix: Remove tough-cookie package

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -203,10 +203,17 @@ packages:
       js-yaml: 3.13.1
     dev: false
 
+  /@azure/abort-controller/2.1.2:
+    resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
   /@azure/cognitiveservices-luis-authoring/4.0.0-preview.1:
     resolution: {integrity: sha512-HAhnf+57iHn1s7U5H7Rr51JZQINeJeT0uxtXr/Ksa6wbmZDOm+VApWnFwp/+QH1ZnW8S6Qf0roKtuTeEBjmBZA==}
     dependencies:
-      '@azure/ms-rest-js': 2.0.5
+      '@azure/ms-rest-js': 2.7.0
       tslib: 1.11.1
     transitivePeerDependencies:
       - encoding
@@ -215,33 +222,48 @@ packages:
   /@azure/cognitiveservices-luis-runtime/5.0.0:
     resolution: {integrity: sha512-HzrRVohaqHdbvxEmON2JThnjfPFpF4PW05RDg8sRS7KsfetjozgQhP57vjJH2ERkJlAWUkoQCtLboAswCWcZQA==}
     dependencies:
-      '@azure/ms-rest-js': 2.0.5
+      '@azure/ms-rest-js': 2.7.0
       tslib: 1.11.1
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /@azure/core-auth/1.8.0:
+    resolution: {integrity: sha512-YvFMowkXzLbXNM11yZtVLhUCmuG0ex7JKOH366ipjmHBhL3vpDcPAeWF+jf0X+jVXwFqo3UhsWUq4kH0ZPdu/g==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.10.0
+      tslib: 2.6.2
+    dev: false
+
+  /@azure/core-util/1.10.0:
+    resolution: {integrity: sha512-dqLWQsh9Nro1YQU+405POVtXnwrIVqPyfUzc4zXCbThTg7+vNNaiMkwbX9AMXKyoFYFClxmB3s25ZFr3+jZkww==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      tslib: 2.6.2
     dev: false
 
   /@azure/ms-rest-azure-js/2.0.1:
     resolution: {integrity: sha512-5e+A710O7gRFISoV4KI/ZyLQbKmjXxQZ1L8Z/sx7jSUQqmswjTnN4yyIZxs5JzfLVkobU0rXxbi5/LVzaI8QXQ==}
     dependencies:
-      '@azure/ms-rest-js': 2.0.5
+      '@azure/ms-rest-js': 2.7.0
       tslib: 1.11.1
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@azure/ms-rest-js/2.0.5:
-    resolution: {integrity: sha512-zj9/JOSsbaJleZz9k9RXKJMBPA2NBUgsus5iZxGlhK+pDeb8M2ps+lkKhJSwLnlTUj5CvrcN3PZDF2b2nSYCQQ==}
+  /@azure/ms-rest-js/2.7.0:
+    resolution: {integrity: sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==}
     dependencies:
-      '@types/node-fetch': 2.5.5
-      '@types/tunnel': 0.0.1
+      '@azure/core-auth': 1.8.0
       abort-controller: 3.0.0
       form-data: 2.5.1
       node-fetch: 2.6.7
-      tough-cookie: 3.0.1
       tslib: 1.11.1
       tunnel: 0.0.6
-      uuid: 3.4.0
+      uuid: 8.3.2
       xml2js: 0.5.0
     transitivePeerDependencies:
       - encoding
@@ -1219,12 +1241,6 @@ packages:
 
   /@types/supports-color/5.3.0:
     resolution: {integrity: sha512-WxwTXnHTIsk7srax1icjLgX+6w1MUAJbhyCpRP/45paEElsPDQUJZDgr1UpKuL2S3Tb+ZyX9MjWwmcSD4bUoOQ==}
-    dev: false
-
-  /@types/tunnel/0.0.1:
-    resolution: {integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==}
-    dependencies:
-      '@types/node': 13.9.0
     dev: false
 
   /@types/xml2js/0.4.5:
@@ -3552,11 +3568,6 @@ packages:
       sprintf-js: 1.1.3
     dev: false
 
-  /ip-regex/2.1.0:
-    resolution: {integrity: sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=}
-    engines: {node: '>=4'}
-    dev: false
-
   /is-accessor-descriptor/1.0.0:
     resolution: {integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==}
     engines: {node: '>=0.10.0'}
@@ -4893,10 +4904,6 @@ packages:
       resolve: 1.15.1
     dev: false
 
-  /psl/1.7.0:
-    resolution: {integrity: sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==}
-    dev: false
-
   /pump/3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
     dependencies:
@@ -5609,15 +5616,6 @@ packages:
       is-number: 7.0.0
     dev: false
 
-  /tough-cookie/3.0.1:
-    resolution: {integrity: sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==}
-    engines: {node: '>=6'}
-    dependencies:
-      ip-regex: 2.1.0
-      psl: 1.7.0
-      punycode: 2.1.1
-    dev: false
-
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: false
@@ -6215,7 +6213,7 @@ packages:
     dev: false
 
   file:projects/bf-chatdown.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-y6C7SQvE7fqOiAl8VbaVOPAY9XWbQsrxIYObRMKriuXvqyeML9quOKRA2lzWj685GdfVjT4IVyg4d4MczJX5Tw==, tarball: file:projects/bf-chatdown.tgz}
+    resolution: {integrity: sha512-eE+xPOSKXSpqPnfB3ZXWkeU756ojEd00jr1lUMgCwjrrOaxRV52IOd50FHYNPUN/8rKRmUtnHFc1PpKyhdIUVA==, tarball: file:projects/bf-chatdown.tgz}
     id: file:projects/bf-chatdown.tgz
     name: '@rush-temp/bf-chatdown'
     version: 0.0.0
@@ -6373,7 +6371,7 @@ packages:
     dev: false
 
   file:projects/bf-dialog.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-5FLUJkIo8PGHtz1bmp1Z7jY3qQf2Sdb/oSL3pEgSW+gmuBHwOeBiNuk7Ovti/95jXn2fPdwx+A96TqAGeFsi5g==, tarball: file:projects/bf-dialog.tgz}
+    resolution: {integrity: sha512-oKO9HfIC5V89sdhfdirhnb1fFl7YievGLKVI/1Z7vqG4rPNQAI7E6p5UzxA/3H8GoLgpfR6WXkDlWAGHfxUbfw==, tarball: file:projects/bf-dialog.tgz}
     id: file:projects/bf-dialog.tgz
     name: '@rush-temp/bf-dialog'
     version: 0.0.0
@@ -6502,7 +6500,7 @@ packages:
     dev: false
 
   file:projects/bf-lu.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-BjnqDh+VrBfoBz9op1y0185KWlbe414lIwTwpVEzp5KqmHdEVNek7ejFaStZLB+XJZEtBO9pO283MbUJa6PEJw==, tarball: file:projects/bf-lu.tgz}
+    resolution: {integrity: sha512-trsulc30gLvsLGd/6twjomU7JqoW4Wb6g5HQYrOMyLr/PTUA6u/dWp2eutirT398iu7WXR15T10C4MmgO47ndQ==, tarball: file:projects/bf-lu.tgz}
     id: file:projects/bf-lu.tgz
     name: '@rush-temp/bf-lu'
     version: 0.0.0
@@ -6545,7 +6543,7 @@ packages:
     dev: false
 
   file:projects/bf-luis-cli.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-JcKAhrmZBbJywdqCUCrAyp9jTWimu7GGdaisIsOshPu5XxkDmjQHtRVXyPLfhtT3WFSgRaq6jyWi+vaxDjPNqg==, tarball: file:projects/bf-luis-cli.tgz}
+    resolution: {integrity: sha512-zlIqAgzpbkhkiuQS4sT70rZPJxTpGtw9ipQ1wvGkvQMgvCflavzK542oYMvUyVkJVhQO2XBD76FV7admRNWFxQ==, tarball: file:projects/bf-luis-cli.tgz}
     id: file:projects/bf-luis-cli.tgz
     name: '@rush-temp/bf-luis-cli'
     version: 0.0.0
@@ -6631,7 +6629,7 @@ packages:
     dev: false
 
   file:projects/bf-orchestrator.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-qs1PqHeG3uFhgEFtd2b7iWYUmVGL/2I79VyDxaAqQaEQKiGZJAcbsdgvB18l5aBMZqjKPlnWbqEr2KWOCcyKjQ==, tarball: file:projects/bf-orchestrator.tgz}
+    resolution: {integrity: sha512-wI6GcvkcJxiTpS/cGchwruFWXep/w9eaSXlJ53LRDpi7JF+SEDWFc5KETY8Lhp5sz9XSooWfAVhHPekbzhDKog==, tarball: file:projects/bf-orchestrator.tgz}
     id: file:projects/bf-orchestrator.tgz
     name: '@rush-temp/bf-orchestrator'
     version: 0.0.0
@@ -6667,7 +6665,7 @@ packages:
     dev: false
 
   file:projects/bf-qnamaker.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-7xG2K3WlkPkOrRqQXcebq+39LnqQYXJc/JVvltwe+ctTnbvw7QGguqe1eoxWKV7mHrC9Oj+2Yb7ULB4g2HTtQw==, tarball: file:projects/bf-qnamaker.tgz}
+    resolution: {integrity: sha512-yNuHfuz9FagHCGf06+v/1EP5Tl9VjfwCfDst6CCxlI/f+3C+Zc5vJBCvkh+sjuqtq0MHqc0vwqfNrtFWy3lwhg==, tarball: file:projects/bf-qnamaker.tgz}
     id: file:projects/bf-qnamaker.tgz
     name: '@rush-temp/bf-qnamaker'
     version: 0.0.0


### PR DESCRIPTION
#minor

## Description
This PR fixes the 'Prototype Pollution vulnerability' vulnerability in the [tough-cookie ](https://www.npmjs.com/package/tough-cookie) package by removing the vulnerable version in _pnpm-lock.yaml_ file.

## Specific Changes
  - Removed the vulnerable version of the _tough-cookie_ package (3.0.1) in the **pnpm-lock.yaml** file by updating _@azure/ms-rest-js_.

## Testing
The following image shows the _tough-cookie_ package isn't installed anymore.
![image](https://github.com/user-attachments/assets/3aa14909-6a3c-4ec3-a136-cc5de448660c)


