### PR TITLE
fix: Remove vulnerability in word-wrap package

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4623,7 +4623,7 @@ packages:
       levn: 0.3.0
       prelude-ls: 1.1.2
       type-check: 0.3.2
-      word-wrap: 1.2.3
+      word-wrap: 1.2.5
     dev: false
 
   /os-tmpdir/1.0.2:
@@ -6042,8 +6042,8 @@ packages:
       is-number: 3.0.0
     dev: false
 
-  /word-wrap/1.2.3:
-    resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
+  /word-wrap/1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -6215,7 +6215,7 @@ packages:
     dev: false
 
   file:projects/bf-chatdown.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-y6C7SQvE7fqOiAl8VbaVOPAY9XWbQsrxIYObRMKriuXvqyeML9quOKRA2lzWj685GdfVjT4IVyg4d4MczJX5Tw==, tarball: file:projects/bf-chatdown.tgz}
+    resolution: {integrity: sha512-eE+xPOSKXSpqPnfB3ZXWkeU756ojEd00jr1lUMgCwjrrOaxRV52IOd50FHYNPUN/8rKRmUtnHFc1PpKyhdIUVA==, tarball: file:projects/bf-chatdown.tgz}
     id: file:projects/bf-chatdown.tgz
     name: '@rush-temp/bf-chatdown'
     version: 0.0.0
@@ -6373,7 +6373,7 @@ packages:
     dev: false
 
   file:projects/bf-dialog.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-5FLUJkIo8PGHtz1bmp1Z7jY3qQf2Sdb/oSL3pEgSW+gmuBHwOeBiNuk7Ovti/95jXn2fPdwx+A96TqAGeFsi5g==, tarball: file:projects/bf-dialog.tgz}
+    resolution: {integrity: sha512-oKO9HfIC5V89sdhfdirhnb1fFl7YievGLKVI/1Z7vqG4rPNQAI7E6p5UzxA/3H8GoLgpfR6WXkDlWAGHfxUbfw==, tarball: file:projects/bf-dialog.tgz}
     id: file:projects/bf-dialog.tgz
     name: '@rush-temp/bf-dialog'
     version: 0.0.0
@@ -6502,7 +6502,7 @@ packages:
     dev: false
 
   file:projects/bf-lu.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-BjnqDh+VrBfoBz9op1y0185KWlbe414lIwTwpVEzp5KqmHdEVNek7ejFaStZLB+XJZEtBO9pO283MbUJa6PEJw==, tarball: file:projects/bf-lu.tgz}
+    resolution: {integrity: sha512-trsulc30gLvsLGd/6twjomU7JqoW4Wb6g5HQYrOMyLr/PTUA6u/dWp2eutirT398iu7WXR15T10C4MmgO47ndQ==, tarball: file:projects/bf-lu.tgz}
     id: file:projects/bf-lu.tgz
     name: '@rush-temp/bf-lu'
     version: 0.0.0
@@ -6545,7 +6545,7 @@ packages:
     dev: false
 
   file:projects/bf-luis-cli.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-JcKAhrmZBbJywdqCUCrAyp9jTWimu7GGdaisIsOshPu5XxkDmjQHtRVXyPLfhtT3WFSgRaq6jyWi+vaxDjPNqg==, tarball: file:projects/bf-luis-cli.tgz}
+    resolution: {integrity: sha512-zlIqAgzpbkhkiuQS4sT70rZPJxTpGtw9ipQ1wvGkvQMgvCflavzK542oYMvUyVkJVhQO2XBD76FV7admRNWFxQ==, tarball: file:projects/bf-luis-cli.tgz}
     id: file:projects/bf-luis-cli.tgz
     name: '@rush-temp/bf-luis-cli'
     version: 0.0.0
@@ -6631,7 +6631,7 @@ packages:
     dev: false
 
   file:projects/bf-orchestrator.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-qs1PqHeG3uFhgEFtd2b7iWYUmVGL/2I79VyDxaAqQaEQKiGZJAcbsdgvB18l5aBMZqjKPlnWbqEr2KWOCcyKjQ==, tarball: file:projects/bf-orchestrator.tgz}
+    resolution: {integrity: sha512-wI6GcvkcJxiTpS/cGchwruFWXep/w9eaSXlJ53LRDpi7JF+SEDWFc5KETY8Lhp5sz9XSooWfAVhHPekbzhDKog==, tarball: file:projects/bf-orchestrator.tgz}
     id: file:projects/bf-orchestrator.tgz
     name: '@rush-temp/bf-orchestrator'
     version: 0.0.0
@@ -6667,7 +6667,7 @@ packages:
     dev: false
 
   file:projects/bf-qnamaker.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-7xG2K3WlkPkOrRqQXcebq+39LnqQYXJc/JVvltwe+ctTnbvw7QGguqe1eoxWKV7mHrC9Oj+2Yb7ULB4g2HTtQw==, tarball: file:projects/bf-qnamaker.tgz}
+    resolution: {integrity: sha512-yNuHfuz9FagHCGf06+v/1EP5Tl9VjfwCfDst6CCxlI/f+3C+Zc5vJBCvkh+sjuqtq0MHqc0vwqfNrtFWy3lwhg==, tarball: file:projects/bf-qnamaker.tgz}
     id: file:projects/bf-qnamaker.tgz
     name: '@rush-temp/bf-qnamaker'
     version: 0.0.0


### PR DESCRIPTION
#minor

## Description
This PR fixes the 'Regular Expression Denial of Service' vulnerability in the [word-wrap](https://www.npmjs.com/package/word-wrap) package by updating the vulnerable version in _pnpm-lock.yaml_ file.

## Specific Changes
  - Removed the vulnerable version of the _word-wrap_ package (1.2.3) in the **pnpm-lock.yaml** file by updating it to its latest version.

## Testing
The following image shows the _word-wrap_ new package version.
![image](https://github.com/user-attachments/assets/4eceb990-e89e-4a03-bf81-2fcf4ad2d54e)



