### PR TITLE
fix: Remove vulnerability in debug package

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -105,18 +105,18 @@ dependencies:
   '@istanbuljs/nyc-config-typescript': 1.0.2_nyc@15.1.0
   '@microsoft/orchestrator-core': 4.15.1
   '@oclif/parser': 3.8.17
-  '@rush-temp/bf-chatdown': file:projects/bf-chatdown.tgz_debug@4.1.1
+  '@rush-temp/bf-chatdown': file:projects/bf-chatdown.tgz_debug@4.3.7
   '@rush-temp/bf-cli-command': file:projects/bf-cli-command.tgz
   '@rush-temp/bf-cli-config': file:projects/bf-cli-config.tgz
   '@rush-temp/bf-cli-plugins': file:projects/bf-cli-plugins.tgz
-  '@rush-temp/bf-dialog': file:projects/bf-dialog.tgz_debug@4.1.1
+  '@rush-temp/bf-dialog': file:projects/bf-dialog.tgz_debug@4.3.7
   '@rush-temp/bf-dispatcher': file:projects/bf-dispatcher.tgz
-  '@rush-temp/bf-lg-cli': file:projects/bf-lg-cli.tgz_debug@4.1.1
-  '@rush-temp/bf-lu': file:projects/bf-lu.tgz_debug@4.1.1
-  '@rush-temp/bf-luis-cli': file:projects/bf-luis-cli.tgz_debug@4.1.1
-  '@rush-temp/bf-orchestrator': file:projects/bf-orchestrator.tgz_debug@4.1.1
+  '@rush-temp/bf-lg-cli': file:projects/bf-lg-cli.tgz_debug@4.3.7
+  '@rush-temp/bf-lu': file:projects/bf-lu.tgz_debug@4.3.7
+  '@rush-temp/bf-luis-cli': file:projects/bf-luis-cli.tgz_debug@4.3.7
+  '@rush-temp/bf-orchestrator': file:projects/bf-orchestrator.tgz_debug@4.3.7
   '@rush-temp/bf-orchestrator-cli': file:projects/bf-orchestrator-cli.tgz
-  '@rush-temp/bf-qnamaker': file:projects/bf-qnamaker.tgz_debug@4.1.1
+  '@rush-temp/bf-qnamaker': file:projects/bf-qnamaker.tgz_debug@4.3.7
   '@rush-temp/botframework-cli': file:projects/botframework-cli.tgz
   '@snyk/nuget-semver': 1.3.0
   '@types/ansi-styles': 3.2.1
@@ -133,7 +133,7 @@ dependencies:
   antlr4: 4.9.2
   applicationinsights: 1.7.3
   argparse: 1.0.10
-  axios: 1.7.7_debug@4.1.1
+  axios: 1.7.7_debug@4.3.7
   botbuilder-lg: 4.22.3
   botframework-schema: 4.22.3
   camelcase: 4.1.0
@@ -141,7 +141,7 @@ dependencies:
   cli-table3: 0.5.1
   clone: 2.1.2
   console-stream: 0.1.1
-  debug: 4.1.1
+  debug: 4.3.7
   deep-equal: 1.1.1
   eslint: 5.16.0
   eslint-config-oclif: 3.1.0_eslint@5.16.0
@@ -1387,16 +1387,18 @@ packages:
     resolution: {integrity: sha512-amQ5OSW3OpIkrxVKLjxVBPk/T49yuOtnqs1z5ZPfZr0+OpTovzmiHbyoAGDIsu5SNYHwOZFp/3LGOnRaALFa/g==}
     dev: false
 
-  /agent-base/4.3.0:
-    resolution: {integrity: sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==}
-    engines: {node: '>= 4.0.0'}
-    dependencies:
-      es6-promisify: 5.0.0
-    dev: false
-
   /agent-base/6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /agent-base/7.1.1:
+    resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
+    engines: {node: '>= 14'}
     dependencies:
       debug: 4.3.7
     transitivePeerDependencies:
@@ -1605,10 +1607,10 @@ packages:
     resolution: {integrity: sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==}
     dev: false
 
-  /axios/1.7.7_debug@4.1.1:
+  /axios/1.7.7_debug@4.3.7:
     resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
     dependencies:
-      follow-redirects: 1.15.6_debug@4.1.1
+      follow-redirects: 1.15.9_debug@4.3.7
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -2230,31 +2232,6 @@ packages:
     resolution: {integrity: sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==}
     dev: false
 
-  /debug/3.2.6:
-    resolution: {integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==}
-    deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
-    dependencies:
-      ms: 2.1.3
-    dev: false
-
-  /debug/4.1.1:
-    resolution: {integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==}
-    dependencies:
-      ms: 2.1.2
-    dev: false
-
-  /debug/4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-    dev: false
-
   /debug/4.3.4_supports-color@8.1.1:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -2558,16 +2535,6 @@ packages:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
     dev: false
 
-  /es6-promise/4.2.8:
-    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
-    dev: false
-
-  /es6-promisify/5.0.0:
-    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
-    dependencies:
-      es6-promise: 4.2.8
-    dev: false
-
   /escalade/3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
@@ -2729,7 +2696,7 @@ packages:
       ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.5
-      debug: 4.3.4
+      debug: 4.3.7
       doctrine: 3.0.0
       eslint-scope: 4.0.3
       eslint-utils: 1.4.3
@@ -3020,8 +2987,8 @@ packages:
     resolution: {integrity: sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==}
     dev: false
 
-  /follow-redirects/1.15.6_debug@4.1.1:
-    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+  /follow-redirects/1.15.9_debug@4.3.7:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3029,7 +2996,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.1.1
+      debug: 4.3.7
     dev: false
 
   /foreground-child/2.0.0:
@@ -3406,19 +3373,21 @@ packages:
       - supports-color
     dev: false
 
-  /https-proxy-agent/2.2.4:
-    resolution: {integrity: sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==}
-    engines: {node: '>= 4.5.0'}
-    dependencies:
-      agent-base: 4.3.0
-      debug: 3.2.6
-    dev: false
-
   /https-proxy-agent/5.0.0:
     resolution: {integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==}
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
+      debug: 4.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /https-proxy-agent/7.0.5:
+    resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.1
       debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
@@ -3807,7 +3776,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -4415,7 +4384,7 @@ packages:
     resolution: {integrity: sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==}
     engines: {node: '>= 10.13'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -5357,7 +5326,7 @@ packages:
     resolution: {integrity: sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - supports-color
@@ -6214,8 +6183,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  file:projects/bf-chatdown.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-y6C7SQvE7fqOiAl8VbaVOPAY9XWbQsrxIYObRMKriuXvqyeML9quOKRA2lzWj685GdfVjT4IVyg4d4MczJX5Tw==, tarball: file:projects/bf-chatdown.tgz}
+  file:projects/bf-chatdown.tgz_debug@4.3.7:
+    resolution: {integrity: sha512-eE+xPOSKXSpqPnfB3ZXWkeU756ojEd00jr1lUMgCwjrrOaxRV52IOd50FHYNPUN/8rKRmUtnHFc1PpKyhdIUVA==, tarball: file:projects/bf-chatdown.tgz}
     id: file:projects/bf-chatdown.tgz
     name: '@rush-temp/bf-chatdown'
     version: 0.0.0
@@ -6232,7 +6201,7 @@ packages:
       '@types/mocha': 10.0.6
       '@types/node': 11.15.7
       '@types/rimraf': 2.0.3
-      axios: 1.7.7_debug@4.1.1
+      axios: 1.7.7_debug@4.3.7
       botframework-schema: 4.22.3
       chai: 4.4.1
       chalk: 2.4.1
@@ -6372,8 +6341,8 @@ packages:
       - supports-color
     dev: false
 
-  file:projects/bf-dialog.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-5FLUJkIo8PGHtz1bmp1Z7jY3qQf2Sdb/oSL3pEgSW+gmuBHwOeBiNuk7Ovti/95jXn2fPdwx+A96TqAGeFsi5g==, tarball: file:projects/bf-dialog.tgz}
+  file:projects/bf-dialog.tgz_debug@4.3.7:
+    resolution: {integrity: sha512-oKO9HfIC5V89sdhfdirhnb1fFl7YievGLKVI/1Z7vqG4rPNQAI7E6p5UzxA/3H8GoLgpfR6WXkDlWAGHfxUbfw==, tarball: file:projects/bf-dialog.tgz}
     id: file:projects/bf-dialog.tgz
     name: '@rush-temp/bf-dialog'
     version: 0.0.0
@@ -6396,7 +6365,7 @@ packages:
       '@types/seedrandom': 2.4.28
       '@types/xml2js': 0.4.5
       ajv: 6.12.6
-      axios: 1.7.7_debug@4.1.1
+      axios: 1.7.7_debug@4.3.7
       chai: 4.4.1
       chalk: 2.4.2
       clone: 2.1.2
@@ -6455,7 +6424,7 @@ packages:
       - supports-color
     dev: false
 
-  file:projects/bf-lg-cli.tgz_debug@4.1.1:
+  file:projects/bf-lg-cli.tgz_debug@4.3.7:
     resolution: {integrity: sha512-AVmzH6g+AqRc5WEdiSXVHhPfmPn5jh2YYLu2xjYfMyUjR9qVKr7Nj8UHzmEavg4e1y1nnWO3zCnRjejzUc7OuQ==, tarball: file:projects/bf-lg-cli.tgz}
     id: file:projects/bf-lg-cli.tgz
     name: '@rush-temp/bf-lg-cli'
@@ -6475,7 +6444,7 @@ packages:
       '@types/node-fetch': 2.5.4
       '@types/readline-sync': 1.4.3
       adaptive-expressions: 4.22.3
-      axios: 1.7.7_debug@4.1.1
+      axios: 1.7.7_debug@4.3.7
       botbuilder-lg: 4.22.3
       chai: 4.4.1
       delay: 4.3.0
@@ -6501,8 +6470,8 @@ packages:
       - supports-color
     dev: false
 
-  file:projects/bf-lu.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-BjnqDh+VrBfoBz9op1y0185KWlbe414lIwTwpVEzp5KqmHdEVNek7ejFaStZLB+XJZEtBO9pO283MbUJa6PEJw==, tarball: file:projects/bf-lu.tgz}
+  file:projects/bf-lu.tgz_debug@4.3.7:
+    resolution: {integrity: sha512-trsulc30gLvsLGd/6twjomU7JqoW4Wb6g5HQYrOMyLr/PTUA6u/dWp2eutirT398iu7WXR15T10C4MmgO47ndQ==, tarball: file:projects/bf-lu.tgz}
     id: file:projects/bf-lu.tgz
     name: '@rush-temp/bf-lu'
     version: 0.0.0
@@ -6515,7 +6484,7 @@ packages:
       '@types/node': 11.15.7
       '@types/node-fetch': 2.5.5
       antlr4: 4.9.2
-      axios: 1.7.7_debug@4.1.1
+      axios: 1.7.7_debug@4.3.7
       chai: 4.4.1
       chalk: 2.4.1
       console-stream: 0.1.1
@@ -6544,8 +6513,8 @@ packages:
       - supports-color
     dev: false
 
-  file:projects/bf-luis-cli.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-JcKAhrmZBbJywdqCUCrAyp9jTWimu7GGdaisIsOshPu5XxkDmjQHtRVXyPLfhtT3WFSgRaq6jyWi+vaxDjPNqg==, tarball: file:projects/bf-luis-cli.tgz}
+  file:projects/bf-luis-cli.tgz_debug@4.3.7:
+    resolution: {integrity: sha512-zlIqAgzpbkhkiuQS4sT70rZPJxTpGtw9ipQ1wvGkvQMgvCflavzK542oYMvUyVkJVhQO2XBD76FV7admRNWFxQ==, tarball: file:projects/bf-luis-cli.tgz}
     id: file:projects/bf-luis-cli.tgz
     name: '@rush-temp/bf-luis-cli'
     version: 0.0.0
@@ -6568,7 +6537,7 @@ packages:
       '@types/node-fetch': 2.5.5
       '@types/rimraf': 2.0.3
       '@types/sinon': 7.5.2
-      axios: 1.7.7_debug@4.1.1
+      axios: 1.7.7_debug@4.3.7
       chai: 4.4.1
       cli-ux: 5.3.3
       fs-extra: 8.1.0
@@ -6630,8 +6599,8 @@ packages:
       - supports-color
     dev: false
 
-  file:projects/bf-orchestrator.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-qs1PqHeG3uFhgEFtd2b7iWYUmVGL/2I79VyDxaAqQaEQKiGZJAcbsdgvB18l5aBMZqjKPlnWbqEr2KWOCcyKjQ==, tarball: file:projects/bf-orchestrator.tgz}
+  file:projects/bf-orchestrator.tgz_debug@4.3.7:
+    resolution: {integrity: sha512-wI6GcvkcJxiTpS/cGchwruFWXep/w9eaSXlJ53LRDpi7JF+SEDWFc5KETY8Lhp5sz9XSooWfAVhHPekbzhDKog==, tarball: file:projects/bf-orchestrator.tgz}
     id: file:projects/bf-orchestrator.tgz
     name: '@rush-temp/bf-orchestrator'
     version: 0.0.0
@@ -6642,7 +6611,7 @@ packages:
       '@types/mocha': 10.0.6
       '@types/node': 11.15.7
       '@types/sinon': 9.0.11
-      axios: 1.7.7_debug@4.1.1
+      axios: 1.7.7_debug@4.3.7
       chai: 4.4.1
       eslint: 5.16.0
       fast-text-encoding: 1.0.3
@@ -6666,8 +6635,8 @@ packages:
       - supports-color
     dev: false
 
-  file:projects/bf-qnamaker.tgz_debug@4.1.1:
-    resolution: {integrity: sha512-7xG2K3WlkPkOrRqQXcebq+39LnqQYXJc/JVvltwe+ctTnbvw7QGguqe1eoxWKV7mHrC9Oj+2Yb7ULB4g2HTtQw==, tarball: file:projects/bf-qnamaker.tgz}
+  file:projects/bf-qnamaker.tgz_debug@4.3.7:
+    resolution: {integrity: sha512-tjEl0QytWA5L+k50KFp+J7j1w/3HuRAVuabhVkiIeSDodfUlTAkptLverc7CPraaSeMtBlEBqQYci3uTaIr5Xw==, tarball: file:projects/bf-qnamaker.tgz}
     id: file:projects/bf-qnamaker.tgz
     name: '@rush-temp/bf-qnamaker'
     version: 0.0.0
@@ -6684,7 +6653,7 @@ packages:
       '@types/mocha': 10.0.6
       '@types/nock': 11.1.0
       '@types/node': 11.15.7
-      axios: 1.7.7_debug@4.1.1
+      axios: 1.7.7_debug@4.3.7
       camelcase: 4.1.0
       chai: 4.4.1
       chalk: 2.4.1
@@ -6695,7 +6664,7 @@ packages:
       fs-extra: 5.0.0
       get-stdin: 6.0.0
       globby: 11.1.0
-      https-proxy-agent: 2.2.4
+      https-proxy-agent: 7.0.5
       intercept-stdout: 0.1.2
       md5: 2.2.1
       mocha: 10.4.0

--- a/packages/qnamaker/package.json
+++ b/packages/qnamaker/package.json
@@ -64,7 +64,7 @@
     "cli-ux": "^5.6.2",
     "fs-extra": "^5.0.0",
     "get-stdin": "^6.0.0",
-    "https-proxy-agent": "^2.2.1",
+    "https-proxy-agent": "^7.0.5",
     "intercept-stdout": "^0.1.2",
     "md5": "^2.2.1",
     "node-fetch": "2.6.7",


### PR DESCRIPTION
#minor

## Description
This PR fixes the 'Regular Expression Denial of Service' vulnerability in the [debug](https://www.npmjs.com/package/debug) package by replacing the vulnerable versions in _pnpm-lock.yaml_ file.

## Specific Changes
  - Replaced the vulnerable versions of the _debug_ package (3.2.6 and 4.1.1) in the **pnpm-lock.yaml** file with a patched version by upgrading the version of _https-proxy-agent_ to the latest and reinstalling _follow-redirects_ and _axios_ packages.

## Testing
The following image shows the safe versions of _debug_ installed after the changes.
![image](https://github.com/user-attachments/assets/9f237839-b61b-42d2-a6ed-d58a6649608a)